### PR TITLE
Fix typo in debug comment

### DIFF
--- a/EMV_Library/OfflineDataAuthentication.cpp
+++ b/EMV_Library/OfflineDataAuthentication.cpp
@@ -1329,7 +1329,7 @@ bool OfflineDataAuthentication::isValidCertificate (const byte *rid,
 	memcpy (cur_cert + 6, serial_num, 3);
 
 	// ***************
-	// The following code is needed only for debug purpoces
+       // The following code is needed only for debug purposes
 	/*opEvent.resetEvent (true);
 	Cnfg->addOperationEvent (&opEvent);
 	res = Cnfg->setValueByteString(CNFG_TERMINAL, 


### PR DESCRIPTION
## Summary
- fix a typo in a debug comment inside `OfflineDataAuthentication.cpp`

## Testing
- `grep -n "debug purpose" -n EMV_Library/OfflineDataAuthentication.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6876d3f0016883238851c3732fff0bc2